### PR TITLE
Fix error when $workOrder->parentWorkOrder null (change_orders table is empty).

### DIFF
--- a/resources/views/workorders/workorder_home.blade.php
+++ b/resources/views/workorders/workorder_home.blade.php
@@ -296,10 +296,12 @@
                                                 </table>
                                             </td>
                                         </tr>
-                                    @elseif ($workOrder->parentWorkOrder->count() > 0)
 
                                     @endif
                                     {{--
+                                    @elseif ($workOrder->parentWorkOrder !== null && $workOrder->parentWorkOrder->count() > 0)
+                                        <!-- -->
+
                                     <tr>
                                         <td>Clone Work Order</td>
                                         <td>


### PR DESCRIPTION
Fix error when $workOrder->parentWorkOrder null (change_orders table is empty).